### PR TITLE
fix: adicionar configuração de roles do Identity

### DIFF
--- a/src/Backend/DevXpert.Store.Core/Application/Configurations/MvcConfig.cs
+++ b/src/Backend/DevXpert.Store.Core/Application/Configurations/MvcConfig.cs
@@ -25,6 +25,7 @@ namespace DevXpert.Store.Core.Application.Configurations
 
             builder.Services
                    .AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true)
+                   .AddRoles<IdentityRole>()
                    .AddEntityFrameworkStores<AppDbContext>();
 
             builder.Services.AddControllersWithViews(options =>


### PR DESCRIPTION
Corrige a configuração do ASP.NET Core Identity para suportar roles. Adiciona AddRoles<IdentityRole>() que estava faltando para o funcionamento adequado das roles já definidas no SeedDatabase.

- Resolve problema de autorização baseada em papéis
- Permite funcionamento correto dos roles Administrator, Vendedor e Cliente