### PR TITLE
fix: unificar caminho de imagens entre API e MVC

### DIFF
--- a/src/Backend/DevXpert.Store.API/Configurations/ApiConfig.cs
+++ b/src/Backend/DevXpert.Store.API/Configurations/ApiConfig.cs
@@ -2,6 +2,8 @@
 using DevXpert.Store.Core.Data.Context;
 using Microsoft.AspNetCore.Identity;
 using System.Diagnostics.CodeAnalysis;
+using DevXpert.Store.Core.Business.Models.Settings;
+using Microsoft.Extensions.FileProviders;
 
 namespace DevXpert.Store.API.Configurations
 {
@@ -78,12 +80,28 @@ namespace DevXpert.Store.API.Configurations
                 app.UseCors("Default");
                 app.UseDeveloperExceptionPage();
             }
+            
+            var mvcWwwRootPath = Path.Combine(
+                Directory.GetParent(app.Environment.ContentRootPath)!.FullName,
+                "DevXpert.Store.MVC", 
+                "wwwroot", 
+                "imagens"
+            );
+            
+            if (!Directory.Exists(mvcWwwRootPath))
+                Directory.CreateDirectory(mvcWwwRootPath);
+            
+            var staticFileOptions = new StaticFileOptions
+            {
+                FileProvider = new PhysicalFileProvider(mvcWwwRootPath),
+                RequestPath = "/imagens"
+            };
 
             app.UseGlobalizationConfig()
                .UseHttpsRedirection()
                .UseMiddleware<ExceptionMiddleware>()
                .UseMiddleware<SecurityMiddleware>(app.Environment)
-               .UseStaticFiles()
+               .UseStaticFiles(staticFileOptions)
                .UseRouting()
                .UseAuthentication()
                .UseAuthorization();

--- a/src/Backend/DevXpert.Store.API/appsettings.Development.json
+++ b/src/Backend/DevXpert.Store.API/appsettings.Development.json
@@ -5,7 +5,7 @@
     "Password": "123"
   },
   "ArquivoSettings": {
-    "BasePath": "~/imagens/development/",
+    "BasePath": "../DevXpert.Store.MVC/wwwroot/imagens/",
     "DefaultImage": "00000000-0000-0000-0000-000000000000_imagem.jpg"
   },
   "JWTSettings": {

--- a/src/Backend/DevXpert.Store.API/appsettings.Staging.json
+++ b/src/Backend/DevXpert.Store.API/appsettings.Staging.json
@@ -5,7 +5,7 @@
     "Password": "123"
   },
   "ArquivoSettings": {
-    "BasePath": "~/imagens/development/",
+    "BasePath": "../DevXpert.Store.MVC/wwwroot/imagens/",
     "DefaultImage": "00000000-0000-0000-0000-000000000000_imagem.jpg"
   },
   "JWTSettings": {


### PR DESCRIPTION
- Atualizar BasePath em appsettings para apontar para wwwroot/imagens do MVC
- Configurar servir arquivos estáticos da pasta de imagens do projeto MVC na API
- Adicionar criação automática do diretório de imagens se não existir
- Padronizar gerenciamento de arquivos entre os projetos API e MVC